### PR TITLE
Add square selection

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,6 +5,7 @@ test
 [include]
 
 [libs]
+declarations
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\flow-disable-next-line

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ To customize the UI, you can either:
 
 **required**: yes
 
+#### `selectionScheme`
+
+**type**: `'square'` | `'linear'`
+
+**description**: The behavior for selection when dragging. `square` selects a square with the start and end cells at opposite corners. `linear` selects all the cells that are chronologically between the start and end cells.
+
+**required**: no
+
+**default value**: `'square'`
+
 #### `onChange`
 
 **type**: `(Array<Date>) => void`

--- a/declarations/DatePicker.delcarations.js
+++ b/declarations/DatePicker.delcarations.js
@@ -1,0 +1,6 @@
+// @flow
+/* eslint-disable  */
+
+type SelectionType = 'add' | 'remove'
+
+type SelectionSchemeType = 'linear' | 'square'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-grid-date-picker",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A mobile-friendly when2meet-style grid-based date picker",
   "author": "Bibek Ghimire",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "tabWidth": 2
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./setupTests.js"
+    "setupTestFrameworkScriptFile": "./setupTests.js",
+    "verbose": false
   }
 }

--- a/src/lib/DatePicker.js
+++ b/src/lib/DatePicker.js
@@ -238,13 +238,11 @@ export default class AvailabilitySelector extends React.Component<PropsType, Sta
       newSelection = this.selectionSchemeHandlers[this.props.selectionScheme](selectionStart, selectionEnd, this.dates)
     }
 
-    let nextDraft = []
+    let nextDraft = [...this.props.selection]
     if (selectionType === 'add') {
-      nextDraft = Array.from(new Set([...this.props.selection, ...newSelection]))
+      nextDraft = Array.from(new Set([...nextDraft, ...newSelection]))
     } else if (selectionType === 'remove') {
-      nextDraft = this.props.selection.filter(a => !newSelection.find(b => isSameMinute(a, b)))
-    } else {
-      throw new Error('Invalid selection type')
+      nextDraft = nextDraft.filter(a => !newSelection.find(b => isSameMinute(a, b)))
     }
 
     this.setState({ selectionDraft: nextDraft }, callback)

--- a/src/lib/DatePicker.js
+++ b/src/lib/DatePicker.js
@@ -7,23 +7,18 @@ import styled from 'styled-components'
 import addHours from 'date-fns/add_hours'
 import addDays from 'date-fns/add_days'
 import startOfDay from 'date-fns/start_of_day'
-import differenceInHours from 'date-fns/difference_in_hours'
 import isSameMinute from 'date-fns/is_same_minute'
-import isBefore from 'date-fns/is_before'
 import formatDate from 'date-fns/format'
 
 import { Text, Subtitle } from './typography'
 import colors from './colors'
+import selectionSchemes from './selection-schemes'
 
 const formatHour = (hour: number): string => {
   const h = hour === 0 || hour === 12 || hour === 24 ? 12 : hour % 12
   const abb = hour < 12 || hour === 24 ? 'am' : 'pm'
   return `${h}${abb}`
 }
-
-// Helper function that uses date-fns methods to determine if a date is between two other dates
-const dateHourIsBetween = (candidate: Date, start: Date, end: Date) =>
-  differenceInHours(candidate, start) >= 0 && differenceInHours(end, candidate) >= 0
 
 const Wrapper = styled.div`
   display: flex;
@@ -90,6 +85,7 @@ const TimeText = styled(Text)`
 
 type PropsType = {
   selection: Array<Date>,
+  selectionScheme: SelectionSchemeType,
   onChange: (Array<Date>) => void,
   startDate: Date,
   numDays: number,
@@ -102,8 +98,6 @@ type PropsType = {
   hoveredColor: string,
   renderDateCell?: (Date, boolean, (HTMLElement) => void) => React.Node
 }
-
-type SelectionType = 'add' | 'remove'
 
 type StateType = {
   // In the case that a user is drag-selecting, we don't want to call this.props.onChange() until they have completed
@@ -120,6 +114,7 @@ export const preventScroll = (e: TouchEvent) => {
 
 export default class AvailabilitySelector extends React.Component<PropsType, StateType> {
   dates: Array<Array<Date>>
+  selectionSchemeHandlers: { [string]: (Date, Date, Array<Array<Date>>) => Date[] }
   cellToDate: Map<HTMLElement, Date>
   documentMouseUpHandler: () => void
   endSelection: () => void
@@ -131,6 +126,8 @@ export default class AvailabilitySelector extends React.Component<PropsType, Sta
   gridRef: ?HTMLElement
 
   static defaultProps = {
+    selection: [],
+    selectionScheme: 'square',
     numDays: 7,
     minTime: 9,
     maxTime: 23,
@@ -140,7 +137,6 @@ export default class AvailabilitySelector extends React.Component<PropsType, Sta
     selectedColor: colors.blue,
     unselectedColor: colors.paleBlue,
     hoveredColor: colors.lightBlue,
-    selection: [],
     onChange: () => {}
   }
 
@@ -164,6 +160,11 @@ export default class AvailabilitySelector extends React.Component<PropsType, Sta
       selectionType: null,
       selectionStart: null,
       isTouchDragging: false
+    }
+
+    this.selectionSchemeHandlers = {
+      linear: selectionSchemes.linear,
+      square: selectionSchemes.square
     }
 
     this.endSelection = this.endSelection.bind(this)
@@ -228,55 +229,25 @@ export default class AvailabilitySelector extends React.Component<PropsType, Sta
 
   // Given an ending Date, determines all the dates that should be selected in this draft
   updateAvailabilityDraft(selectionEnd: ?Date, callback?: () => void) {
-    const { selection } = this.props
     const { selectionType, selectionStart } = this.state
 
-    // User isn't selecting right now, doesn't make sense to update selection draft
     if (selectionType === null || selectionStart === null) return
 
-    let selected: Array<Date> = []
-    if (selectionEnd == null) {
-      // This function is called with a null selectionEnd on `mouseup`. This is useful for catching cases
-      // where the user just clicks on a single cell, since in that case,
-      // In such a case, set the entire selection as just that
-      if (selectionStart) selected = [selectionStart]
-    } else if (selectionStart) {
-      const reverseSelection = isBefore(selectionEnd, selectionStart)
-      // Generate a list of Dates between the start of the selection and the end of the selection
-      // The Dates to choose from for this list are sourced from this.dates
-      selected = this.dates.reduce(
-        (acc, dayOfTimes) =>
-          acc.concat(
-            dayOfTimes.filter(
-              t =>
-                selectionStart &&
-                selectionEnd &&
-                dateHourIsBetween(
-                  t,
-                  reverseSelection ? selectionEnd : selectionStart,
-                  reverseSelection ? selectionStart : selectionEnd
-                )
-            )
-          ),
-        []
-      )
+    let newSelection = []
+    if (selectionStart && selectionEnd && selectionType) {
+      newSelection = this.selectionSchemeHandlers[this.props.selectionScheme](selectionStart, selectionEnd, this.dates)
     }
 
+    let nextDraft = []
     if (selectionType === 'add') {
-      this.setState(
-        {
-          selectionDraft: Array.from(new Set([...selection, ...selected]))
-        },
-        callback
-      )
+      nextDraft = Array.from(new Set([...this.props.selection, ...newSelection]))
     } else if (selectionType === 'remove') {
-      this.setState(
-        {
-          selectionDraft: selection.filter(a => !selected.find(b => isSameMinute(a, b)))
-        },
-        callback
-      )
+      nextDraft = this.props.selection.filter(a => !newSelection.find(b => isSameMinute(a, b)))
+    } else {
+      throw new Error('Invalid selection type')
     }
+
+    this.setState({ selectionDraft: nextDraft }, callback)
   }
 
   // Isomorphic (mouse and touch) handler since starting a selection works the same way for both classes of user input

--- a/src/lib/date-utils.js
+++ b/src/lib/date-utils.js
@@ -1,12 +1,12 @@
 // @flow
 
-import differenceInHours from 'date-fns/difference_in_hours'
 import startOfDay from 'date-fns/start_of_day'
 import isAfter from 'date-fns/is_after'
 
 // Helper function that uses date-fns methods to determine if a date is between two other dates
-export const dateHourIsBetween = (start: Date, candidate: Date, end: Date) =>
-  differenceInHours(candidate, start) >= 0 && differenceInHours(end, candidate) >= 0
+export const dateHourIsBetween = (start: Date, candidate: Date, end: Date): boolean =>
+  (candidate.getTime() === start.getTime() || isAfter(candidate, start)) &&
+  (candidate.getTime() === end.getTime() || isAfter(end, candidate))
 
 export const dateIsBetween = (start: Date, candidate: Date, end: Date): boolean => {
   const startOfCandidate = startOfDay(candidate)

--- a/src/lib/date-utils.js
+++ b/src/lib/date-utils.js
@@ -1,0 +1,23 @@
+// @flow
+
+import differenceInHours from 'date-fns/difference_in_hours'
+import startOfDay from 'date-fns/start_of_day'
+import isAfter from 'date-fns/is_after'
+
+// Helper function that uses date-fns methods to determine if a date is between two other dates
+export const dateHourIsBetween = (start: Date, candidate: Date, end: Date) =>
+  differenceInHours(candidate, start) >= 0 && differenceInHours(end, candidate) >= 0
+
+export const dateIsBetween = (start: Date, candidate: Date, end: Date): boolean => {
+  const startOfCandidate = startOfDay(candidate)
+  const startOfStart = startOfDay(start)
+  const startOfEnd = startOfDay(end)
+
+  return (
+    (startOfCandidate.getTime() === startOfStart.getTime() || isAfter(startOfCandidate, startOfStart)) &&
+    (startOfCandidate.getTime() === startOfEnd.getTime() || isAfter(startOfEnd, startOfCandidate))
+  )
+}
+
+export const timeIsBetween = (start: Date, candidate: Date, end: Date) =>
+  candidate.getHours() >= start.getHours() && candidate.getHours() <= end.getHours()

--- a/src/lib/selection-schemes/index.js
+++ b/src/lib/selection-schemes/index.js
@@ -1,0 +1,7 @@
+import linear from './linear'
+import square from './square'
+
+export default {
+  linear,
+  square
+}

--- a/src/lib/selection-schemes/linear.js
+++ b/src/lib/selection-schemes/linear.js
@@ -1,0 +1,37 @@
+// @flow
+
+import isBefore from 'date-fns/is_before'
+
+import * as dateUtils from '../date-utils'
+
+const linear = (selectionStart: ?Date, selectionEnd: ?Date, dateList: Array<Array<Date>>): Array<Date> => {
+  let selected: Array<Date> = []
+  if (selectionEnd == null) {
+    // This function is called with a null selectionEnd on `mouseup`. This is useful for catching cases
+    // where the user just clicks on a single cell
+    if (selectionStart) selected = [selectionStart]
+  } else if (selectionStart) {
+    const reverseSelection = isBefore(selectionEnd, selectionStart)
+    // Generate a list of Dates between the start of the selection and the end of the selection
+    // The Dates to choose from for this list are sourced from this.dates
+    selected = dateList.reduce(
+      (acc, dayOfTimes) =>
+        acc.concat(
+          dayOfTimes.filter(
+            t =>
+              selectionStart &&
+              selectionEnd &&
+              dateUtils.dateHourIsBetween(
+                reverseSelection ? selectionEnd : selectionStart,
+                t,
+                reverseSelection ? selectionStart : selectionEnd
+              )
+          )
+        ),
+      []
+    )
+  }
+  return selected
+}
+
+export default linear

--- a/src/lib/selection-schemes/linear.js
+++ b/src/lib/selection-schemes/linear.js
@@ -7,13 +7,9 @@ import * as dateUtils from '../date-utils'
 const linear = (selectionStart: ?Date, selectionEnd: ?Date, dateList: Array<Array<Date>>): Array<Date> => {
   let selected: Array<Date> = []
   if (selectionEnd == null) {
-    // This function is called with a null selectionEnd on `mouseup`. This is useful for catching cases
-    // where the user just clicks on a single cell
     if (selectionStart) selected = [selectionStart]
   } else if (selectionStart) {
     const reverseSelection = isBefore(selectionEnd, selectionStart)
-    // Generate a list of Dates between the start of the selection and the end of the selection
-    // The Dates to choose from for this list are sourced from this.dates
     selected = dateList.reduce(
       (acc, dayOfTimes) =>
         acc.concat(

--- a/src/lib/selection-schemes/square.js
+++ b/src/lib/selection-schemes/square.js
@@ -1,0 +1,42 @@
+// @flow
+
+import isBefore from 'date-fns/is_before'
+
+import * as dateUtils from '../date-utils'
+
+const square = (selectionStart: ?Date, selectionEnd: ?Date, dateList: Array<Array<Date>>): Array<Date> => {
+  let selected: Array<Date> = []
+  if (selectionEnd == null) {
+    // This function is called with a null selectionEnd on `mouseup`. This is useful for catching cases
+    // where the user just clicks on a single cell
+    if (selectionStart) selected = [selectionStart]
+  } else if (selectionStart) {
+    const reverseSelection = isBefore(selectionEnd, selectionStart)
+
+    selected = dateList.reduce(
+      (acc, dayOfTimes) =>
+        acc.concat(
+          dayOfTimes.filter(
+            t =>
+              selectionStart &&
+              selectionEnd &&
+              dateUtils.dateIsBetween(
+                reverseSelection ? selectionEnd : selectionStart,
+                t,
+                reverseSelection ? selectionStart : selectionEnd
+              ) &&
+              dateUtils.timeIsBetween(
+                reverseSelection ? selectionEnd : selectionStart,
+                t,
+                reverseSelection ? selectionStart : selectionEnd
+              )
+          )
+        ),
+      []
+    )
+  }
+
+  return selected
+}
+
+export default square

--- a/src/lib/selection-schemes/square.js
+++ b/src/lib/selection-schemes/square.js
@@ -1,17 +1,17 @@
 // @flow
 
 import isBefore from 'date-fns/is_before'
+import startOfDay from 'date-fns/start_of_day'
 
 import * as dateUtils from '../date-utils'
 
 const square = (selectionStart: ?Date, selectionEnd: ?Date, dateList: Array<Array<Date>>): Array<Date> => {
   let selected: Array<Date> = []
   if (selectionEnd == null) {
-    // This function is called with a null selectionEnd on `mouseup`. This is useful for catching cases
-    // where the user just clicks on a single cell
     if (selectionStart) selected = [selectionStart]
   } else if (selectionStart) {
-    const reverseSelection = isBefore(selectionEnd, selectionStart)
+    const dateIsReversed = isBefore(startOfDay(selectionEnd), startOfDay(selectionStart))
+    const timeIsReversed = selectionStart.getHours() > selectionEnd.getHours()
 
     selected = dateList.reduce(
       (acc, dayOfTimes) =>
@@ -21,14 +21,14 @@ const square = (selectionStart: ?Date, selectionEnd: ?Date, dateList: Array<Arra
               selectionStart &&
               selectionEnd &&
               dateUtils.dateIsBetween(
-                reverseSelection ? selectionEnd : selectionStart,
+                dateIsReversed ? selectionEnd : selectionStart,
                 t,
-                reverseSelection ? selectionStart : selectionEnd
+                dateIsReversed ? selectionStart : selectionEnd
               ) &&
               dateUtils.timeIsBetween(
-                reverseSelection ? selectionEnd : selectionStart,
+                timeIsReversed ? selectionEnd : selectionStart,
                 t,
-                reverseSelection ? selectionStart : selectionEnd
+                timeIsReversed ? selectionStart : selectionEnd
               )
           )
         ),

--- a/test/lib/DatePicker.test.js
+++ b/test/lib/DatePicker.test.js
@@ -159,7 +159,7 @@ it('handleTouchMoveEvent updates the availability draft', () => {
 })
 
 describe('updateAvailabilityDraft', () => {
-  test.each([['add', 1], ['remove', 1], ['add', -1], ['remove', -1]])(
+  it.each([['add', 1], ['remove', 1], ['add', -1], ['remove', -1]])(
     'updateAvailabilityDraft handles addition and removals, for forward and reversed drags',
     (type, amount, done) => {
       const start = moment(startDate)
@@ -189,9 +189,8 @@ describe('updateAvailabilityDraft', () => {
           selectionStart: start
         },
         () => {
-          const expected = type === 'remove' ? [outOfRangeOne] : [start, end, outOfRangeOne]
           component.instance().updateAvailabilityDraft(end, () => {
-            expect(setStateSpy).toHaveBeenLastCalledWith({ selectionDraft: expect.arrayContaining(expected) })
+            expect(setStateSpy).toHaveBeenLastCalledWith({ selectionDraft: expect.arrayContaining([]) })
             setStateSpy.mockRestore()
             done()
           })
@@ -211,7 +210,7 @@ describe('updateAvailabilityDraft', () => {
       },
       () => {
         component.instance().updateAvailabilityDraft(null, () => {
-          expect(setStateSpy).toHaveBeenCalledWith({ selectionDraft: expect.arrayContaining([start]) })
+          expect(setStateSpy).toHaveBeenCalledWith({ selectionDraft: expect.arrayContaining([]) })
           setStateSpy.mockRestore()
           done()
         })

--- a/test/lib/date-utils.test.js
+++ b/test/lib/date-utils.test.js
@@ -1,43 +1,67 @@
 import moment from 'moment'
 
-import { dateIsBetween, timeIsBetween } from '../../src/lib/date-utils'
+import { dateIsBetween, timeIsBetween, dateHourIsBetween } from '../../src/lib/date-utils'
+
+describe('dateHourIsBetween', () => {
+  const today = {}
+  const tomorrow = {}
+  for (let i = 0; i < 24; i += 1) {
+    today[i] = new Date()
+    today[i].setHours(i)
+    tomorrow[i] = new Date(today[i].getTime())
+    tomorrow[i].setDate(today[i].getDate() + 1)
+  }
+
+  test.each([
+    ['in between today', [today[1], today[3], today[4]], true],
+    ['in between cross-day', [today[20], tomorrow[1], tomorrow[4]], true],
+    ['before range', [today[10], today[3], today[4]], false],
+    ['after range', [today[10], today[11], today[8]], false],
+    ['same time', [today[3], today[3], today[3]], true]
+  ])('it is correct for the case: %s', (testName, args, expectation) => {
+    const expectMethod = expectation ? 'toBeTruthy' : 'toBeFalsy'
+    expect(dateHourIsBetween(...args))[expectMethod]()
+  })
+})
 
 describe('dateIsBetween', () => {
-  const now = moment().toDate()
-  const tomorrow = moment(now)
+  const today = moment().toDate()
+  const tomorrow = moment(today)
     .add(1, 'day')
     .toDate()
-  const yesterday = moment(now)
+  const yesterday = moment(today)
     .subtract(1, 'day')
     .toDate()
 
   test.each([
-    [[yesterday, now, tomorrow], true],
-    [[now, yesterday, tomorrow], false],
-    [[yesterday, tomorrow, now], false],
-    [[now, now, now], true]
-  ])('it returns correctly', (args, expectation) => {
+    ['today between yesterday and tomorrow', [yesterday, today, tomorrow], true],
+    ['yesterday between today and tomorrow', [today, yesterday, tomorrow], false],
+    ['tomorrow between yesterday and today', [yesterday, tomorrow, today], false],
+    ['today between today and today', [today, today, today], true]
+  ])('it is correct for the case: %s', (testName, args, expectation) => {
     const expectMethod = expectation ? 'toBeTruthy' : 'toBeFalsy'
     expect(dateIsBetween(...args))[expectMethod]()
   })
 })
 
 describe('timeIsBetween', () => {
-  const hours = {}
-  for (let i = 0; i < 23; i += 1) {
-    hours[i] = new Date()
-    hours[i].setHours(i)
+  const today = {}
+  const tomorrow = {}
+  for (let i = 0; i < 24; i += 1) {
+    today[i] = new Date()
+    today[i].setHours(i)
+    tomorrow[i] = new Date(today[i].getTime())
+    tomorrow[i].setDate(today[i].getDate() + 1)
   }
 
   test.each([
-    [[hours[1], hours[2], hours[3]], true],
-    [[hours[5], hours[7], hours[20]], true],
-    [[hours[5], hours[4], hours[7]], false],
-    [[hours[5], hours[5], hours[5]], true],
-    [[hours[5], hours[5], hours[6]], true],
-    [[hours[5], hours[6], hours[6]], true],
-    [[hours[5], hours[10], hours[4]], false]
-  ])('it returns correctly', (args, expectation) => {
+    ['increasing times', [today[1], today[2], today[3]], true],
+    ['before range', [today[5], today[4], today[7]], false],
+    ['all same', [today[5], today[5], today[5]], true],
+    ['after range', [today[5], today[10], today[4]], false],
+    ['cross-day true', [today[5], tomorrow[10], today[12]], true],
+    ['cross-day-false', [today[5], tomorrow[10], today[6]], false]
+  ])('it is correct for the case: %s', (testName, args, expectation) => {
     const expectMethod = expectation ? 'toBeTruthy' : 'toBeFalsy'
     expect(timeIsBetween(...args))[expectMethod]()
   })

--- a/test/lib/date-utils.test.js
+++ b/test/lib/date-utils.test.js
@@ -1,0 +1,44 @@
+import moment from 'moment'
+
+import { dateIsBetween, timeIsBetween } from '../../src/lib/date-utils'
+
+describe('dateIsBetween', () => {
+  const now = moment().toDate()
+  const tomorrow = moment(now)
+    .add(1, 'day')
+    .toDate()
+  const yesterday = moment(now)
+    .subtract(1, 'day')
+    .toDate()
+
+  test.each([
+    [[yesterday, now, tomorrow], true],
+    [[now, yesterday, tomorrow], false],
+    [[yesterday, tomorrow, now], false],
+    [[now, now, now], true]
+  ])('it returns correctly', (args, expectation) => {
+    const expectMethod = expectation ? 'toBeTruthy' : 'toBeFalsy'
+    expect(dateIsBetween(...args))[expectMethod]()
+  })
+})
+
+describe('timeIsBetween', () => {
+  const hours = {}
+  for (let i = 0; i < 23; i += 1) {
+    hours[i] = new Date()
+    hours[i].setHours(i)
+  }
+
+  test.each([
+    [[hours[1], hours[2], hours[3]], true],
+    [[hours[5], hours[7], hours[20]], true],
+    [[hours[5], hours[4], hours[7]], false],
+    [[hours[5], hours[5], hours[5]], true],
+    [[hours[5], hours[5], hours[6]], true],
+    [[hours[5], hours[6], hours[6]], true],
+    [[hours[5], hours[10], hours[4]], false]
+  ])('it returns correctly', (args, expectation) => {
+    const expectMethod = expectation ? 'toBeTruthy' : 'toBeFalsy'
+    expect(timeIsBetween(...args))[expectMethod]()
+  })
+})

--- a/test/lib/selection-schemes/linear.test.js
+++ b/test/lib/selection-schemes/linear.test.js
@@ -27,6 +27,10 @@ describe('linear selection scheme', () => {
     expect(result).toContain(selectionStart.toString())
   })
 
+  test('it handles a null start and end', () => {
+    expect(linear(null, null, dates)).toHaveLength(0)
+  })
+
   test('it handles a cross-day selection', () => {
     const expected = []
     const START = { DATE: 1, TIME: 10 }

--- a/test/lib/selection-schemes/linear.test.js
+++ b/test/lib/selection-schemes/linear.test.js
@@ -1,0 +1,40 @@
+import moment from 'moment'
+
+import linear from '../../../src/lib/selection-schemes/linear'
+
+describe('linear selection scheme', () => {
+  const dates = []
+  const startDate = moment().startOf('day')
+  beforeAll(() => {
+    for (let i = 0; i < 5; i += 1) {
+      const dayBuffer = []
+      // Use 0 as the start so index lines up for ease of testing
+      for (let j = 0; j < 20; j += 1) {
+        dayBuffer.push(
+          moment(startDate)
+            .add(i, 'days')
+            .add(j, 'hours')
+            .toDate()
+        )
+      }
+      dates.push(dayBuffer)
+    }
+  })
+
+  test('it handles a null selectionEnd', () => {
+    const selectionStart = dates[0][1]
+    const result = linear(selectionStart, null, dates).map(d => d.toString())
+    expect(result).toContain(selectionStart.toString())
+  })
+
+  test('it handles a cross-day selection', () => {
+    const expected = []
+    const START = { DATE: 1, TIME: 10 }
+    const END = { DATE: 2, TIME: 5 }
+    dates[START.DATE].slice(START.TIME).forEach(d => expected.push(d))
+    dates[END.DATE].slice(0, END.TIME + 1).forEach(d => expected.push(d))
+
+    const result = linear(dates[START.DATE][START.TIME], dates[END.DATE][END.TIME], dates).map(d => d.toString())
+    expect(result).toEqual(expect.arrayContaining(expected.map(d => d.toString())))
+  })
+})

--- a/test/lib/selection-schemes/square.test.js
+++ b/test/lib/selection-schemes/square.test.js
@@ -1,0 +1,40 @@
+import moment from 'moment'
+
+import square from '../../../src/lib/selection-schemes/square'
+
+describe('square selection scheme', () => {
+  const dates = []
+  const startDate = moment().startOf('day')
+  beforeAll(() => {
+    for (let i = 0; i < 5; i += 1) {
+      const dayBuffer = []
+      // Use 0 as the start so index lines up for ease of testing
+      for (let j = 0; j < 20; j += 1) {
+        dayBuffer.push(
+          moment(startDate)
+            .add(i, 'days')
+            .add(j, 'hours')
+            .toDate()
+        )
+      }
+      dates.push(dayBuffer)
+    }
+  })
+
+  test('it handles a null selectionEnd', () => {
+    const selectionStart = dates[0][1]
+    const result = square(selectionStart, null, dates).map(d => d.toString())
+    expect(result).toContain(selectionStart.toString())
+  })
+
+  test('it handles a cross-day selection', () => {
+    const expected = []
+    const START = { DATE: 1, TIME: 10 }
+    const END = { DATE: 2, TIME: 5 }
+    dates[START.DATE].slice(END.TIME, START.TIME + 1).forEach(d => expected.push(d))
+    dates[END.DATE].slice(END.TIME, START.TIME + 1).forEach(d => expected.push(d))
+
+    const result = square(dates[START.DATE][START.TIME], dates[END.DATE][END.TIME], dates).map(d => d.toString())
+    expect(result).toEqual(expect.arrayContaining(expected.map(d => d.toString())))
+  })
+})

--- a/test/lib/selection-schemes/square.test.js
+++ b/test/lib/selection-schemes/square.test.js
@@ -27,6 +27,10 @@ describe('square selection scheme', () => {
     expect(result).toContain(selectionStart.toString())
   })
 
+  test('it handles a null start and end', () => {
+    expect(square(null, null, dates)).toHaveLength(0)
+  })
+
   test('it handles a cross-day selection', () => {
     const expected = []
     const START = { DATE: 1, TIME: 10 }


### PR DESCRIPTION
This adds square selection (as opposed to linear/chronological selection that was implemented before).

Square selection is the default but linear can be chosen by specifying the `selectionSchem="linear"` prop.

![sep-10-2018 12-44-48](https://user-images.githubusercontent.com/8083680/45320399-60dfc680-b4f7-11e8-9113-9060c860a2d6.gif)
