### PR TITLE
Patch to Max time slot render

### DIFF
--- a/src/lib/ScheduleSelector.tsx
+++ b/src/lib/ScheduleSelector.tsx
@@ -148,7 +148,7 @@ export default class ScheduleSelector extends React.Component<PropsType, StateTy
     const minutesInChunk = Math.floor(60 / props.hourlyChunks)
     for (let d = 0; d < props.numDays; d += 1) {
       const currentDay = []
-      for (let h = props.minTime; h < props.maxTime; h += 1) {
+      for (let h = props.minTime; h <= props.maxTime; h += 1) {
         for (let c = 0; c < props.hourlyChunks; c += 1) {
           currentDay.push(addMinutes(addHours(addDays(startTime, d), h), c * minutesInChunk))
         }


### PR DESCRIPTION
- Max time slot was missing in the render. 
- Added the missing `<=` to render the max time slot